### PR TITLE
Maven / Typed Runtime Exception / Several filter mapping.

### DIFF
--- a/classes.mk
+++ b/classes.mk
@@ -10,4 +10,7 @@ CLASSES=\
 	net.sourceforge.spnego.SpnegoHttpURLConnection	\
 	net.sourceforge.spnego.SpnegoPrincipal	\
 	net.sourceforge.spnego.SpnegoProvider	\
-	net.sourceforge.spnego.SpnegoSOAPConnection
+	net.sourceforge.spnego.SpnegoSOAPConnection	\
+	net.sourceforge.spnego.SpnegoGSSException	\
+	net.sourceforge.spnego.SpnegoUnauthenticatedException	\
+	net.sourceforge.spnego.SpnegoUnsupportedOperationException

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.sourceforge.spnego</groupId>
+  <artifactId>spnego</artifactId>
+  <version>r8-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>SPNEGO SourceForge</name>
+  
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>  
+</project>

--- a/src/net/sourceforge/spnego/SpnegoAuthenticator.java
+++ b/src/net/sourceforge/spnego/SpnegoAuthenticator.java
@@ -100,6 +100,9 @@ public final class SpnegoAuthenticator {
     
     /** Default GSSManager. */
     private static final GSSManager MANAGER = GSSManager.getInstance();
+
+    /** Flag to indicate if typed runtime exception is thrown. */
+    private final transient boolean throwTypedRuntimeException;
     
     /** Flag to indicate if BASIC Auth is allowed. */
     private final transient boolean allowBasic;
@@ -141,8 +144,9 @@ public final class SpnegoAuthenticator {
 
         LOGGER.fine("config=" + config);
 
+        this.throwTypedRuntimeException = config.isTypedRuntimeExceptionThrown();
         this.allowBasic = config.isBasicAllowed();
-        this.allowUnsecure = config.isUnsecureAllowed();  
+        this.allowUnsecure = config.isUnsecureAllowed();
         this.clientModuleName = config.getClientLoginModule();
         this.allowLocalhost = config.isLocalhostAllowed();
         this.promptIfNtlm = config.downgradeNtlm();
@@ -489,5 +493,14 @@ public final class SpnegoAuthenticator {
     private boolean isLocalhost(final HttpServletRequest req) {
         
         return req.getLocalAddr().equals(req.getRemoteAddr());
+    }
+
+    /**
+     * Returns true if typed runtime exceptions have to be thrown.
+     *
+     * @return true if typed runtime exceptions have to be thrown
+     */
+    public boolean isTypedRuntimeExceptionThrown() {
+        return throwTypedRuntimeException;
     }
 }

--- a/src/net/sourceforge/spnego/SpnegoFilterConfig.java
+++ b/src/net/sourceforge/spnego/SpnegoFilterConfig.java
@@ -70,6 +70,24 @@ final class SpnegoFilterConfig { // NOPMD
     
     private static transient SpnegoFilterConfig instance = null;
 
+    /**
+     * true if typed runtime exception have to be thrown and handled behind by the server application.
+     * For example :
+     * <error-page>
+     *  <exception-type>net.sourceforge.spnego.SpnegoGSSException</exception-type>
+     *  <location>/technicalError.jsp</location>
+     * </error-page>
+     * <error-page>
+     *  <exception-type>net.sourceforge.spnego.SpnegoUnsupportedOperationException</exception-type>
+     *  <location>/unsupportedOperationError.jsp</location>
+     * </error-page>
+     * <error-page>
+     *  <exception-type>net.sourceforge.spnego.SpnegoUnauthenticatedException</exception-type>
+     *  <location>/unauthenticatedError.jsp</location>
+     * </error-page>
+     */
+    private transient boolean throwTypedRuntimeException = false;
+
     /** true if Basic auth should be offered. */
     private transient boolean allowBasic = false;
     
@@ -161,6 +179,12 @@ final class SpnegoFilterConfig { // NOPMD
         if (null != config.getInitParameter(Constants.ALLOW_DELEGATION)) {
             this.allowDelegation = 
                 Boolean.parseBoolean(config.getInitParameter(Constants.ALLOW_DELEGATION));
+        }
+
+        // determine if the filter should throw typed runtime exception
+        if (null != config.getInitParameter(Constants.THROW_TYPED_RUNTIME_EXCEPTION)) {
+            this.throwTypedRuntimeException =
+                Boolean.parseBoolean(config.getInitParameter(Constants.THROW_TYPED_RUNTIME_EXCEPTION));
         }
     }
     
@@ -297,7 +321,7 @@ final class SpnegoFilterConfig { // NOPMD
     String getServerLoginModule() {
         return this.serverLoginModule;
     }
-    
+
     /**
      * Returns the instance of the servlet's config parameters.
      * 
@@ -316,6 +340,16 @@ final class SpnegoFilterConfig { // NOPMD
         }
 
         return SpnegoFilterConfig.instance;
+    }
+
+
+    /**
+     * Returns true if typed runtime exceptions have to be thrown.
+     *
+     * @return true if typed runtime exceptions have to be thrown
+     */
+    boolean isTypedRuntimeExceptionThrown() {
+        return this.throwTypedRuntimeException;
     }
 
     /**

--- a/src/net/sourceforge/spnego/SpnegoGSSException.java
+++ b/src/net/sourceforge/spnego/SpnegoGSSException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2009 "Darwin V. Felix" <darwinfelix@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+package net.sourceforge.spnego;
+
+import net.sourceforge.spnego.SpnegoHttpFilter.Constants;
+import org.ietf.jgss.GSSException;
+
+/**
+ * Typed runtime exception that wraps a GSSException.
+ * 
+ * @author Yohann Chastagnier
+ *
+ */
+public final class SpnegoGSSException extends RuntimeException {
+    public SpnegoGSSException(final GSSException cause) {
+        super(cause);
+    }
+}

--- a/src/net/sourceforge/spnego/SpnegoUnauthenticatedException.java
+++ b/src/net/sourceforge/spnego/SpnegoUnauthenticatedException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2009 "Darwin V. Felix" <darwinfelix@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+package net.sourceforge.spnego;
+
+/**
+ * Typed runtime exception that handles unauthenticated case.
+ *
+ * @author Yohann Chastagnier
+ *
+ */
+public final class SpnegoUnauthenticatedException extends RuntimeException {
+    public SpnegoUnauthenticatedException(final String message) {
+        super(message);
+    }
+}

--- a/src/net/sourceforge/spnego/SpnegoUnsupportedOperationException.java
+++ b/src/net/sourceforge/spnego/SpnegoUnsupportedOperationException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2009 "Darwin V. Felix" <darwinfelix@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+package net.sourceforge.spnego;
+
+import org.ietf.jgss.GSSException;
+
+/**
+ * Typed runtime exception that handles unsupported operation.
+ * 
+ * @author Yohann Chastagnier
+ *
+ */
+public final class SpnegoUnsupportedOperationException extends RuntimeException {
+    public SpnegoUnsupportedOperationException(final Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Adding apache maven building capabilities.
Adding typed runtime exception that can be used to handle SSO errors in the JEE application (not activated by default, to activate it set the filter parameter "spnego.throw.typedRuntimeException" to true).
Upgrading the SPNEGO HTTP Filter so that it can be used in several URL matching (filter mapping).
